### PR TITLE
fix: handle non-object patch files without traceback

### DIFF
--- a/src/slxdiff/cli.py
+++ b/src/slxdiff/cli.py
@@ -382,7 +382,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.fail_on_change and result.changed:
             return 1
         return 0
-    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+    except (FileNotFoundError, TypeError, ValueError, RuntimeError) as exc:
         print(f"slx-diff: error: {exc}", file=sys.stderr)
         return 2
 

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -334,3 +334,29 @@ def test_cli_doctor_returns_action_required_for_missing_path(monkeypatch, capsys
     )
     assert cli.main(["doctor", str(tmp_path / "missing")]) == 1
     assert "ACTION REQUIRED" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("payload", [[], "not a patch", None], ids=["array", "string", "null"])
+def test_cli_apply_rejects_non_object_patch_without_traceback(
+    capsys, tmp_path: Path, payload: object
+) -> None:
+    from slxdiff import cli
+
+    patch_path = tmp_path / "invalid.json"
+    patch_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    result = cli.main(
+        [
+            "apply",
+            str(tmp_path / "model.slx"),
+            str(patch_path),
+            "-o",
+            str(tmp_path / "output.slx"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert captured.out == ""
+    assert captured.err == "slx-diff: error: patch must be a JSON object\n"
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
## Summary

Closes #8.

- Convert `TypeError` raised while loading a non-object patch into the standard `slx-diff: error: ...` CLI diagnostic.
- Return exit code 2 without a Python traceback for array, string, and `null` patch documents.
- Add regression coverage for all three JSON top-level values.

## Validation

- `python -m pytest -q` — 85 passed, 1 skipped
- `python -m ruff check src tests` — passed
- `python -m ruff format --check .` — passed
- `python -m compileall -q src` — passed

MATLAB is not required for this input-validation path; invalid patches are rejected before the MATLAB bridge is invoked.