### PR TITLE
perf: cache validated XML members during parsing

### DIFF
--- a/src/slxdiff/parser.py
+++ b/src/slxdiff/parser.py
@@ -250,12 +250,22 @@ def _parse_archive(archive: zipfile.ZipFile, *, model_name: str, source: str) ->
     if xml_bytes > _MAX_ARCHIVE_XML_BYTES:
         raise ValueError("SLX package contains too much uncompressed XML to inspect safely")
 
+    # Validate and read each XML member at most once per parse.  The safety
+    # pass below covers every member, while graph extraction may need to read
+    # root and referenced system members again.
+    xml_cache: dict[str, bytes] = {}
+
+    def safe_xml(member: str) -> bytes:
+        if member not in xml_cache:
+            xml_cache[member] = _safe_xml(archive, member)
+        return xml_cache[member]
+
     # Inspect every XML member, including metadata/stateflow members that are
     # not part of the graph extraction path, so no archive member is a blind
     # spot for DTD/entity declarations.
     for info in infos:
         if info.filename.lower().endswith(".xml"):
-            _safe_xml(archive, info.filename)
+            safe_xml(info.filename)
 
     names = {info.filename for info in infos}
     root_name = next((candidate for candidate in _ROOT_CANDIDATES if candidate in names), None)
@@ -282,7 +292,7 @@ def _parse_archive(archive: zipfile.ZipFile, *, model_name: str, source: str) ->
             system = inline
         else:
             try:
-                root = ET.fromstring(_safe_xml(archive, member))
+                root = ET.fromstring(safe_xml(member))
             except ET.ParseError as exc:
                 raise ValueError(f"invalid XML in SLX member {member}: {exc}") from exc
             system = _system_element(root)

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -80,6 +80,25 @@ def test_parser_rejects_delayed_and_nested_entities_and_scans_all_members() -> N
         payload.unlink(missing_ok=True)
 
 
+def test_parser_reads_each_xml_member_once_per_parse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from slxdiff import parser as parser_module
+
+    model_path = tmp_path / "cached.slx"
+    _write_slx(model_path, _simple_xml(), extra_xml="<metadata />")
+    calls: list[str] = []
+    original_safe_xml = parser_module._safe_xml
+
+    def tracked_safe_xml(archive, member: str) -> bytes:
+        calls.append(member)
+        return original_safe_xml(archive, member)
+
+    monkeypatch.setattr(parser_module, "_safe_xml", tracked_safe_xml)
+    parse_slx(model_path)
+
+    assert calls.count("simulink/systems/system_root.xml") == 1
+    assert calls.count("metadata/extra.xml") == 1
+
+
 def test_parser_accepts_unicode_and_nested_subsystem_xml(tmp_path: Path) -> None:
     model_path = tmp_path / "nested.slx"
     _write_slx(


### PR DESCRIPTION
## Summary

Closes #11.

- Cache validated XML member bytes for the duration of one SLX parse.
- Keep the complete archive-wide DTD/entity safety scan while avoiding a second ZIP read for root and referenced system members.
- Add regression coverage proving each XML member is passed through the safety reader once per parse.

## Validation

- `python -m pytest -ra` — 86 passed, 1 skipped (MATLAB integration is opt-in)
- `python -m ruff check src tests` — passed
- `python -m ruff format --check .` — passed
- `python -m compileall -q src` — passed
- `git diff --check` — passed

No MATLAB runtime was needed: this is an internal static parser optimization with unchanged model semantics and unchanged archive safety limits.