### PR TITLE
fix: harden incremental workspace indexing

### DIFF
--- a/docs/workspace-index-validation.md
+++ b/docs/workspace-index-validation.md
@@ -1,0 +1,20 @@
+# Workspace index hardening
+
+This follow-up to PR #12 retains the session-scoped, dependency-free index.
+
+- Refresh requests received during a build are coalesced into one follow-up
+  build, including when the active build fails. Writes are no longer silently
+  lost behind an in-progress scan.
+- MATLAB source size limits apply to each search, before cache lookup. A
+  restrictive request cannot poison the cache for later permissive requests.
+- Search resolves indexed paths against the workspace boundary again before
+  accessing content, and rejects file symlinks.
+
+Regression coverage is isolated in `tests/test_workspace_index.py`. The
+concurrency test uses synchronization events rather than depending on directory
+scan speed. This is a correctness improvement, not a measured speedup claim.
+
+Remaining limitations: discovery of external additions still requires Refresh;
+there is no filesystem watcher, persistent database, or gitignore parser. Search
+documents retain the existing 64-document cap. Persistent MATLAB sessions,
+frontend modularization, desktop E2E, and Control Lab remain separate work.

--- a/src/slxdiff/workspace.py
+++ b/src/slxdiff/workspace.py
@@ -144,11 +144,13 @@ class WorkspaceIndex:
         self._state = "idle"
         self._error = ""
         self._generation = 0
+        self._refresh_pending = False
         self._thread: threading.Thread | None = None
         self._schedule_locked()
 
     def _schedule_locked(self) -> None:
         if self._state == "indexing":
+            self._refresh_pending = True
             return
         self._state = "indexing"
         self._error = ""
@@ -167,6 +169,9 @@ class WorkspaceIndex:
                 if generation == self._generation:
                     self._state = "error"
                     self._error = str(exc)
+                    if self._refresh_pending:
+                        self._refresh_pending = False
+                        self._schedule_locked()
             return
         with self._lock:
             if generation != self._generation:
@@ -175,6 +180,9 @@ class WorkspaceIndex:
             self._files = files
             self._state = "ready"
             self._error = ""
+            if self._refresh_pending:
+                self._refresh_pending = False
+                self._schedule_locked()
 
     def invalidate(self) -> None:
         """Schedule a fresh index after a write or an explicit user refresh."""
@@ -185,10 +193,16 @@ class WorkspaceIndex:
 
     def _search_document(self, record: dict[str, Any], *, max_file_bytes: int) -> dict[str, Any] | None:
         relative = str(record["path"])
-        path = self.root / relative
         try:
+            path = resolve_workspace_path(self.root, relative)
+            if (self.root / relative).is_symlink():
+                return None
             stat = path.stat()
-        except OSError:
+        except (OSError, ValueError):
+            return None
+        # Apply each request's limit before looking up a shared document. A small
+        # request must neither reuse oversized text nor poison a later large one.
+        if str(record.get("kind")) == "matlab" and stat.st_size > max_file_bytes:
             return None
         signature = (int(stat.st_mtime_ns), int(stat.st_size))
         with self._lock:
@@ -197,13 +211,10 @@ class WorkspaceIndex:
                 return cached[1]
 
         if str(record.get("kind")) == "matlab":
-            if stat.st_size > max_file_bytes:
-                document: dict[str, Any] = {"text": None}
-            else:
-                try:
-                    document = {"text": read_text_file(self.root, relative)}
-                except (OSError, UnicodeError, ValueError):
-                    return None
+            try:
+                document: dict[str, Any] = {"text": read_text_file(self.root, relative)}
+            except (OSError, UnicodeError, ValueError):
+                return None
         else:
             try:
                 from .parser import parse_slx

--- a/tests/test_workspace_index.py
+++ b/tests/test_workspace_index.py
@@ -1,0 +1,93 @@
+"""Regression coverage for incremental index lifecycle and search boundaries."""
+
+import threading
+import time
+
+import pytest
+
+from slxdiff import workspace
+
+
+def ready(index):
+    deadline = time.monotonic() + 5
+    while index.snapshot()["indexing"] and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert index.snapshot()["index_state"] == "ready"
+
+
+@pytest.mark.parametrize("limits", [(100, 1, 100), (1, 100, 1)])
+def test_search_limit_is_request_scoped(tmp_path, limits):
+    (tmp_path / "controller.m").write_text("target = 42;", encoding="utf-8")
+    index = workspace.WorkspaceIndex(tmp_path)
+    ready(index)
+    for limit in limits:
+        results = index.search("target", max_file_bytes=limit)["results"]
+        assert bool(results) == (limit == 100)
+
+
+@pytest.mark.parametrize("fail_first", [False, True])
+def test_write_during_build_schedules_followup(tmp_path, monkeypatch, fail_first):
+    captured = threading.Event()
+    release = threading.Event()
+    walk = workspace._walk_indexed
+    calls = []
+
+    def blocked(*args, **kwargs):
+        result = walk(*args, **kwargs)
+        calls.append(1)
+        if len(calls) == 1:
+            captured.set()
+            assert release.wait(5)
+            if fail_first:
+                raise OSError("scan interrupted")
+        return result
+
+    monkeypatch.setattr(workspace, "_walk_indexed", blocked)
+    index = workspace.WorkspaceIndex(tmp_path)
+    try:
+        assert captured.wait(5)
+        (tmp_path / "new.m").write_text("target = 1;", encoding="utf-8")
+        index.invalidate()
+        index.invalidate()
+    finally:
+        release.set()
+    ready(index)
+    assert len(calls) == 2
+    assert index.search("target")["results"]
+
+
+def test_search_revalidates_indexed_path(tmp_path, monkeypatch):
+    (tmp_path / "model.slx").write_bytes(b"not a model")
+    index = workspace.WorkspaceIndex(tmp_path)
+    ready(index)
+    checked = []
+
+    def escaped(root, relative):
+        checked.append(relative)
+        raise ValueError("workspace path escapes the workspace root")
+
+    monkeypatch.setattr(workspace, "resolve_workspace_path", escaped)
+    assert index.search("Gain")["results"] == []
+    assert checked == ["model.slx"]
+
+
+def test_unchanged_search_reuses_text_and_detects_external_edit(tmp_path, monkeypatch):
+    path = tmp_path / "controller.m"
+    path.write_text("target = 1;", encoding="utf-8")
+    index = workspace.WorkspaceIndex(tmp_path)
+    ready(index)
+    read = workspace.read_text_file
+    reads = []
+
+    def counted(*args):
+        reads.append(1)
+        return read(*args)
+
+    monkeypatch.setattr(workspace, "read_text_file", counted)
+    assert index.search("target")["results"]
+    assert index.search("target")["results"]
+    assert len(reads) == 1
+    path.write_text("replacement = 200;", encoding="utf-8")
+    assert not index.search("target")["results"]
+    assert index.search("replacement")["results"]
+    assert len(reads) == 2


### PR DESCRIPTION
Follow-up to #12. Fix refresh requests lost during active or failing scans, enforce per-request source size limits before cache lookup, and revalidate indexed paths before SLX search. Adds six focused regression cases including unchanged-read reuse and external edit detection. No new runtime dependencies or MATLAB execution changes. Validation: 93 passed, 1 optional MATLAB test skipped; ruff check and format passed. Stacked on PR #12; not a replacement for the persistent MATLAB backend or the full attached roadmap.